### PR TITLE
Fix sidebar sticky positioning

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -105,9 +105,11 @@ body.loading .loading-modal {
     font-size: 23px;
 }
 
-#blog-card {
-    position: sticky;
-    top: 0;
+@media (min-height: 880px) {
+    #blog-card {
+        position: sticky;
+        top: 76px;
+    }
 }
 
 .card-title {


### PR DESCRIPTION
This increases the top-distance for the sticky positioning to account for the sticky categories nav, and also wraps the sidebar sticky styling in a media query to ensure that the viewport is tall enough to view all of the sidebar content (prevents content being cut-off until the end of the page).